### PR TITLE
pitchTrackerGUI: simplify

### DIFF
--- a/launchers/pitchTrackerGUI
+++ b/launchers/pitchTrackerGUI
@@ -4,7 +4,5 @@
 #////////////////////////////////////////////////////////
 # startup script for the pitchtracker
 #////////////////////////////////////////////////////////
-# If this script is killed, kill everything.
-trap "kill -- -$$" EXIT
 
-pd -nodac -nomidi -jack ../PureData/OscSendVoc.pd &
+exec pd -nodac -nomidi -jack ../PureData/OscSendVoc.pd


### PR DESCRIPTION
Don't really understand how the previous script worked at all. It would kill the running `pd` immediately, since the script exits after launching it, right?